### PR TITLE
Add sh autogen

### DIFF
--- a/rockspec/sh-scm-1.rockspec
+++ b/rockspec/sh-scm-1.rockspec
@@ -23,6 +23,10 @@ dependencies = {
 build = {
     type = "none",
     install = {
+        bin = {
+            ["sh.autogen"] = "sh.autogen.lua"
+        },
+
         lua = {
             sh = "sh.lua",
         },

--- a/sh.autogen.lua
+++ b/sh.autogen.lua
@@ -62,7 +62,6 @@ for v in assert(os.getenv("PATH")):gmatch("([^:]+)") do
         for file in lfs.dir(v) do
             if file == "." or file == ".." then goto next end
             file = v.."/"..file --For some reason lfs.dir only gives basenames
-            print(file)
 
             local attribs, err = lfs.attributes(file)
             if not attribs then goto next end
@@ -85,7 +84,7 @@ typef:write('\n')
 
 typef:write("---@class sh.Shell\n")
 for i, v in ipairs(execs) do
-    typef:write(string.format("---@field ['%s'] fun(...: string): sh.ReturnType\n", v))
+    typef:write(string.format("---@field ['%s'] fun(...: string | sh.ReturnType): sh.ReturnType\n", v))
 end
 typef:write('\n')
 

--- a/sh.autogen.lua
+++ b/sh.autogen.lua
@@ -1,0 +1,94 @@
+#!/usr/bin/env lua
+
+--[[
+    Automatically generate lua-language-server types
+]]--
+
+---@type LuaFileSystem
+local lfs = require("lfs")
+
+local function isdir(path)
+    return (lfs.attributes(path) or { mode = "not directory lmao" }).mode == "directory"
+end
+
+
+---Taken from https://github.com/mah0x211/lua-basename/blob/master/basename.lua
+---@param pathname string
+---@return string
+local function basename(pathname)
+    if pathname == nil then
+        return '.'
+    elseif type(pathname) ~= 'string' then
+        error('pathname must be string', 2)
+    end
+
+    -- remove trailing-slashes
+    local head = pathname:find('/+$', 2)
+    if head then
+        pathname = pathname:sub(1, head - 1)
+    end
+
+    -- extract last-segment
+    head = pathname:find('[^/]+$')
+    if head then
+        pathname = pathname:sub(head)
+    end
+
+    -- empty
+    if pathname == '' then
+        return '.'
+    end
+
+    return pathname
+end
+
+local typef = assert(io.open(arg[1] or "sh.types.lua", "w+"))
+
+typef:write("---@meta\n\n")
+
+typef:write [[
+---@class sh.ReturnType : sh.Shell
+---@field __stdout string
+---@field __stderr string?
+---@field __input string?
+---@field __exitcode integer
+
+]]
+
+---@type string[]
+local execs = {}
+for v in assert(os.getenv("PATH")):gmatch("([^:]+)") do
+    if isdir(v) then
+        for file in lfs.dir(v) do
+            if file == "." or file == ".." then goto next end
+            file = v.."/"..file --For some reason lfs.dir only gives basenames
+            print(file)
+
+            local attribs, err = lfs.attributes(file)
+            if not attribs then goto next end
+            if attribs["permissions"]:find("^.-[x]$") then
+                local fname = basename(file)
+                for _, exec in ipairs(execs) do if exec == fname then goto next end end
+                execs[#execs+1] = fname
+            end
+            ::next::
+        end
+    end
+end
+
+typef:write("---@alias sh.CommandName\n")
+for i, v in ipairs(execs) do
+    typef:write(string.format("---|'%s'\n", v))
+end
+
+typef:write('\n')
+
+typef:write("---@class sh.Shell\n")
+for i, v in ipairs(execs) do
+    typef:write(string.format("---@field ['%s'] fun(...: string): sh.ReturnType\n", v))
+end
+typef:write('\n')
+
+typef:flush()
+typef:close()
+

--- a/sh.lua
+++ b/sh.lua
@@ -68,7 +68,7 @@ function Stack:Create()
     return t
 end
 
-
+---@class sh.lua : sh.Shell
 local M = {}
 
 M.version = "Automatic Shell Bindings for Lua / LuaSH 1.0.0"
@@ -376,6 +376,7 @@ M.__index_ignore_function = {"cd", "pushd", "popd", "stdout", "stderr", "print"}
 --
 -- set hook for undefined variables
 --
+---Adds the shell functions into the global table
 local function install()
     mt.__index = function(t, cmd)
         if list_contains(M.__index_ignore_prefix, cmd, prefcmp) then

--- a/sh.lua
+++ b/sh.lua
@@ -297,6 +297,9 @@ M.__raise_errors  = true
 -- returns a function that executes the command with given args and returns its
 -- output, exit status etc
 --
+---@param cmd sh.CommandName | string
+---@param ... string
+---@return fun(...: string): sh.ReturnType
 local function command(cmd, ...)
     local prearg = {...}
     return function(...)

--- a/sh.lua
+++ b/sh.lua
@@ -299,7 +299,7 @@ M.__raise_errors  = true
 --
 ---@param cmd sh.CommandName | string
 ---@param ... string
----@return fun(...: string): sh.ReturnType
+---@return fun(...: string | sh.ReturnType): sh.ReturnType
 local function command(cmd, ...)
     local prearg = {...}
     return function(...)


### PR DESCRIPTION
This allows for automatic generation of [lua language server](https://github.com/sumneko/lua-language-server) type definitions, for editor support for `sh.lua`